### PR TITLE
fix successful message with unsupported vid

### DIFF
--- a/kazuma.py
+++ b/kazuma.py
@@ -105,7 +105,7 @@ def steal(update, context):
             stickerfile.close()
         except UnboundLocalError: # to deal with undefined stickerfile variable
             pass
-        os.system('del '+tempsticker)
+        os.remove(tempsticker)
         reply(msg, None, replymsg)
 
 def stealpack(update, context):
@@ -168,7 +168,7 @@ def stealpack(update, context):
                 pass
         finally: 
             stickerfile.close()
-            os.system('del '+tempsticker)
+            os.remove(tempsticker)
         try: 
             replymsg.edit_text(s.STEALING_PACK.format(oldpack.stickers.index(sticker), len(oldpack.stickers)), parse_mode=ParseMode.MARKDOWN)
         except: 


### PR DESCRIPTION
Fixes the condition where files with bigger size or longer video gets a steal successful output and used `os.remove()` instead of `del` commands 